### PR TITLE
feat: add static JS file to call `/api/svg` endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # prod
 dist/
 
+# we build a .ts file into a .js so we can serve it statically
+static/background-generator.js
+
 # dev
 .yarn/
 !.yarn/releases

--- a/README.md
+++ b/README.md
@@ -25,12 +25,49 @@ allowing customisation of various parameters.
 - **Custom Colours**: Set your own colour scheme for forward and backward diagonals
 - **Persistent Settings**: Preferences are saved between sessions
 
+## Add as a background on any webpage.
+
+The joy of 10 PRINT can be experienced on any webpage. Simply add
+
+```html
+<script type="module" src="https://10print.xyz/background-body.js" />
+```
+
+...inside the `<head>`, and we will set a background on your `<body>` element.
+
+Other elements can be given a background too, and custom parameters used, like:
+
+```html
+<script type="module">
+  import { TENPRINT } from "https://10print.xyz/background-element.js";
+
+  const svg = document.getElementById("svg");
+
+  if (svg === null) {
+    throw new Error("Couldn't find rotato");
+  }
+
+  TENPRINT(svg, {
+    firstColour: "#E7AF18",
+    secondColour: "#ECBF46",
+  });
+</script>
+```
+
+This will set the background of the element with id `svg` to a 10 PRINT SVG with
+the given colours. See [the demo][demo] ([code]) for a live example.
+
+[code]: ./demo.html
+[the demo]: https://10print.xyz/demo
+
 ## Getting Started
 
 ### Prerequisites
 
-- [Node.js] (v18 or newer)
-- [pnpm][pnpm] package manager (v9 or newer)
+_See <./package.json> for canonical dependency requirements._
+
+- [Node.js]
+- [pnpm][pnpm] package manager
 
 [Node.js]: https://nodejs.org/
 [pnpm]: https://pnpm.io/
@@ -38,17 +75,20 @@ allowing customisation of various parameters.
 ### Installation
 
 1. Clone the repository
+
    ```bash
    git clone https://github.com/iainlane/10print.git
    cd 10print
    ```
 
 2. Install dependencies
+
    ```bash
    pnpm install
    ```
 
 3. Start the development server
+
    ```bash
    pnpm run dev
    ```

--- a/background-body.ts
+++ b/background-body.ts
@@ -1,0 +1,52 @@
+import { TENPRINT } from "@/lib/background-js/background";
+import { type PartialConfig, type WidthHeight } from "@/lib/svg-api/helpers";
+
+/**
+ * Use this script like:
+ *
+ * ```html
+ * <script src="https://10print.xyz/static/background-body.js"></script>
+ * ```
+ *
+ * and the `<body>` element will have a background image set to a random 10PRINT
+ * image.
+ *
+ * The image is updated whenever the body is resized.
+ *
+ * If you need to pass custom parameters, see <./background.ts>
+ */
+
+/**
+ * Get current viewport dimensions
+ */
+function getViewportDimensions(): WidthHeight {
+  return {
+    width: window.innerWidth,
+    height: window.innerHeight,
+  };
+}
+
+/**
+ * Initialise the background and set up event listeners
+ */
+function initialise(): void {
+  const dimensions = getViewportDimensions();
+
+  const params: PartialConfig = {
+    width: dimensions.width,
+    height: dimensions.height,
+  };
+
+  TENPRINT(document.body, params);
+}
+
+function run(): void {
+  if (document.readyState !== "loading") {
+    initialise();
+    return;
+  }
+
+  document.addEventListener("DOMContentLoaded", initialise, { once: true });
+}
+
+run();

--- a/background-element.ts
+++ b/background-element.ts
@@ -1,0 +1,3 @@
+import { TENPRINT } from "@/lib/background-js/background";
+
+export { TENPRINT };

--- a/demo.css
+++ b/demo.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/demo.html
+++ b/demo.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>10PRINT demo</title>
+    <link href="./demo.css" rel="stylesheet" />
+    <script type="module" src="./background-body.ts"></script>
+    <script type="module">
+      import { TENPRINT } from "./background-element.ts";
+
+      const svg = document.getElementById("rotatoImage");
+
+      if (svg === null) {
+        throw new Error("Couldn't find rotato");
+      }
+
+      TENPRINT(svg, {
+        gridSize: 50,
+        firstColour: "#E7AF18",
+        secondColour: "#ECBF46",
+      });
+    </script>
+  </head>
+  <body class="flex h-screen w-screen justify-center align-middle">
+    <svg
+      id="rotato"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 100 100"
+      preserveAspectRatio="xMidYMid meet"
+      class="aspect-square h-auto w-[90vmin] animate-[spin_10s_linear_infinite] fill-current"
+    >
+      <circle
+        id="textCircle"
+        cx="50"
+        cy="50"
+        r="45"
+        class="fill-orange-50 stroke-gray-100 opacity-50"
+      />
+      <defs>
+        <clipPath id="circleClip">
+          <use href="#textCircle" />
+        </clipPath>
+
+        <path
+          id="textCirclePath"
+          d="M 5,50 A 45,45 0 1 1 95,50 A 45,45 0 1 1 5,50"
+          fill="none"
+          stroke="none"
+        />
+
+        <linearGradient id="textGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stop-color="currentcolor" class="text-indigo-500" />
+          <stop
+            offset="50%"
+            stop-color="currentcolor"
+            class="text-purple-500"
+          />
+          <stop offset="100%" stop-color="currentcolor" class="text-pink-500" />
+        </linearGradient>
+      </defs>
+
+      <foreignObject width="100" height="100" clip-path="url(#circleClip)">
+        <div id="rotatoImage" class="h-full w-full"></div>
+      </foreignObject>
+
+      <text
+        dominant-baseline="hanging"
+        class="font-mono text-xl"
+        fill="url(#textGradient)"
+      >
+        <textPath
+          id="textPath"
+          href="#textCirclePath"
+          startOffset="0%"
+          textLength="250%"
+          lengthAdjust="spacing"
+          side="right"
+        >
+          why hello there
+        </textPath>
+      </text>
+    </svg>
+  </body>
+</html>

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -1,0 +1,27 @@
+import type { EventContext } from "@cloudflare/workers-types";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+  "Access-Control-Expose-Headers": "location",
+  "Access-Control-Max-Age": "86400",
+};
+
+/**
+ * Middleware for the API. Adds CORS headers to all responses.
+ *
+ * @param context The event context
+ *
+ * @returns A response with CORS headers added.
+ */
+export async function onRequest<Env, P extends string, Data>(
+  context: EventContext<Env, P, Data>,
+) {
+  const response = await context.next();
+
+  Object.entries(corsHeaders).forEach(([key, value]) => {
+    response.headers.set(key, value);
+  });
+
+  return response;
+}

--- a/functions/svg.test.ts
+++ b/functions/svg.test.ts
@@ -22,7 +22,7 @@ function createMockContext<Env, P extends string, Data>(
   return mockContext;
 }
 
-const BASE_URL = "http://localhost/api/svg";
+const BASE_URL = "http://localhost/svg";
 
 describe("SVG API Endpoint (onRequestGet)", () => {
   const defaults = configSchema.parse({});

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "jsdom": "^26.0.0",
     "jsx-runtime": "link:hono/jsx/dom/jsx-runtime",
     "linkedom": "^0.18.9",
+    "lodash.debounce": "^4.0.8",
     "lucide-react": "^0.487.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
@@ -23,7 +24,6 @@
     "tailwind-merge": "^3.0.2",
     "tailwindcss": "^4.0.17",
     "tw-animate-css": "^1.2.5",
-    "use-debounce": "^10.0.4",
     "zod": "^3.24.2"
   },
   "devDependencies": {
@@ -34,11 +34,13 @@
     "@stylistic/eslint-plugin": "4.2.0",
     "@tailwindcss/typography": "0.5.16",
     "@types/jsdom": "21.1.7",
+    "@types/lodash.debounce": "^4.0.9",
     "@types/node": "22.14.0",
     "@types/react": "19.1.0",
     "@types/react-dom": "19.1.1",
     "@vitejs/plugin-react": "4.3.4",
     "@vitest/coverage-v8": "3.1.1",
+    "concurrently": "^9.1.2",
     "eslint": "9.24.0",
     "eslint-config-prettier": "10.1.1",
     "eslint-plugin-no-relative-import-paths": "1.6.1",
@@ -70,7 +72,9 @@
   "scripts": {
     "build": "vite build",
     "deploy": "pnpm run build && wrangler pages deploy",
-    "dev": "pnpm wrangler pages dev",
+    "dev": "concurrently --kill-others-on-fail \"pnpm run dev:build\" \"pnpm run dev:wrangler\"",
+    "dev:build": "vite dev",
+    "dev:wrangler": "pnpm wrangler pages dev",
     "lint": "eslint .",
     "test": "vitest run"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       linkedom:
         specifier: ^0.18.9
         version: 0.18.9
+      lodash.debounce:
+        specifier: ^4.0.8
+        version: 4.0.8
       lucide-react:
         specifier: ^0.487.0
         version: 0.487.0(react@19.1.0)
@@ -81,9 +84,6 @@ importers:
       tw-animate-css:
         specifier: ^1.2.5
         version: 1.2.5
-      use-debounce:
-        specifier: ^10.0.4
-        version: 10.0.4(react@19.1.0)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -109,6 +109,9 @@ importers:
       '@types/jsdom':
         specifier: 21.1.7
         version: 21.1.7
+      '@types/lodash.debounce':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/node':
         specifier: 22.14.0
         version: 22.14.0
@@ -124,6 +127,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 3.1.1
         version: 3.1.1(vitest@3.1.1(@types/node@22.14.0)(happy-dom@17.4.4)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.29.2))
+      concurrently:
+        specifier: ^9.1.2
+        version: 9.1.2
       eslint:
         specifier: 9.24.0
         version: 9.24.0(jiti@2.4.2)
@@ -1451,6 +1457,12 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/lodash.debounce@4.0.9':
+    resolution: {integrity: sha512-Ma5JcgTREwpLRwMM+XwBR7DaWe96nC38uCBDFKZWbNKD+osjVzdpnUSwBcqCptrp16sSOLBAUb50Car5I0TCsQ==}
+
+  '@types/lodash@4.17.16':
+    resolution: {integrity: sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==}
+
   '@types/node@22.14.0':
     resolution: {integrity: sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==}
 
@@ -1689,6 +1701,10 @@ packages:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
 
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -1717,6 +1733,11 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  concurrently@9.1.2:
+    resolution: {integrity: sha512-H9MWcoPsYddwbOGM6difjVwVZHl63nwMEwDJG/L7VGtuaJhb12h2caPG2tVPWs7emuYix252iGfqOyrz1GczTQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -2041,6 +2062,10 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-east-asian-width@1.3.0:
     resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
     engines: {node: '>=18'}
@@ -2353,11 +2378,17 @@ packages:
   lodash.castarray@4.4.0:
     resolution: {integrity: sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==}
 
+  lodash.debounce@4.0.8:
+    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+
   lodash.isplainobject@4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
@@ -2628,6 +2659,10 @@ packages:
     resolution: {integrity: sha512-UkRNRIwnhG+y7hpqnycCL/xbTk7+ia9VuVTC0S+zVbwd65DI9eUpRMfsWIGrCWxTU/mi+JW8cHQCrv+zfCbEPQ==}
     engines: {node: '>=10.13'}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2650,6 +2685,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -2681,6 +2719,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-quote@1.8.2:
+    resolution: {integrity: sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -2756,6 +2798,10 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -2822,6 +2868,10 @@ packages:
   tr46@5.1.0:
     resolution: {integrity: sha512-IUWnUK7ADYR5Sl1fZlO1INDUhVhatWl7BtJWsIhwJ0UAK7ilzzIa8uIqOO/aYVWHZPJkKbEL+362wrzoeRF7bw==}
     engines: {node: '>=18'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -2900,12 +2950,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  use-debounce@10.0.4:
-    resolution: {integrity: sha512-6Cf7Yr7Wk7Kdv77nnJMf6de4HuDE4dTxKij+RqE9rufDsI6zsbjyAxcH5y2ueJCQAnfgKbzXbZHYlkFwmBlWkw==}
-    engines: {node: '>= 16.0.0'}
-    peerDependencies:
-      react: '*'
 
   use-sidecar@1.1.3:
     resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
@@ -3083,8 +3127,20 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -4135,6 +4191,12 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/lodash.debounce@4.0.9':
+    dependencies:
+      '@types/lodash': 4.17.16
+
+  '@types/lodash@4.17.16': {}
+
   '@types/node@22.14.0':
     dependencies:
       undici-types: 6.21.0
@@ -4408,6 +4470,12 @@ snapshots:
 
   cli-spinners@2.9.2: {}
 
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   clsx@2.1.1: {}
 
   color-convert@2.0.1:
@@ -4435,6 +4503,16 @@ snapshots:
   commander@13.1.0: {}
 
   concat-map@0.0.1: {}
+
+  concurrently@9.1.2:
+    dependencies:
+      chalk: 4.1.2
+      lodash: 4.17.21
+      rxjs: 7.8.2
+      shell-quote: 1.8.2
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
 
   convert-source-map@2.0.0: {}
 
@@ -4798,6 +4876,8 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-caller-file@2.0.5: {}
+
   get-east-asian-width@1.3.0: {}
 
   get-intrinsic@1.3.0:
@@ -5103,9 +5183,13 @@ snapshots:
 
   lodash.castarray@4.4.0: {}
 
+  lodash.debounce@4.0.8: {}
+
   lodash.isplainobject@4.0.6: {}
 
   lodash.merge@4.6.2: {}
+
+  lodash@4.17.21: {}
 
   log-symbols@6.0.0:
     dependencies:
@@ -5361,6 +5445,8 @@ snapshots:
       js-yaml: 4.1.0
       strip-bom: 4.0.0
 
+  require-directory@2.1.1: {}
+
   resolve-from@4.0.0: {}
 
   restore-cursor@5.1.0:
@@ -5401,6 +5487,10 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
 
   safer-buffer@2.1.2: {}
 
@@ -5446,6 +5536,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shell-quote@1.8.2: {}
 
   siginfo@2.0.0: {}
 
@@ -5508,6 +5600,10 @@ snapshots:
   strip-json-comments@3.1.1: {}
 
   supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
 
@@ -5583,6 +5679,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  tree-kill@1.2.2: {}
+
   ts-api-utils@2.1.0(typescript@5.8.2):
     dependencies:
       typescript: 5.8.2
@@ -5649,10 +5747,6 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.0
-
-  use-debounce@10.0.4(react@19.1.0):
-    dependencies:
-      react: 19.1.0
 
   use-sidecar@1.1.3(@types/react@19.1.0)(react@19.1.0):
     dependencies:
@@ -5819,7 +5913,21 @@ snapshots:
 
   xmlchars@2.2.0: {}
 
+  y18n@5.0.8: {}
+
   yallist@3.1.1: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
 

--- a/src/hooks/useWindowSize.ts
+++ b/src/hooks/useWindowSize.ts
@@ -1,5 +1,5 @@
+import debounce from "lodash.debounce";
 import { useEffect, useState } from "react";
-import { useDebounce } from "use-debounce";
 
 interface WindowSize {
   width: number;
@@ -12,29 +12,27 @@ export function useWindowSize(debounceMs: number = 100): WindowSize {
     height: window.innerHeight,
   });
 
-  const [debouncedWidth] = useDebounce(windowSize.width, debounceMs);
-  const [debouncedHeight] = useDebounce(windowSize.height, debounceMs);
+  useEffect(
+    function () {
+      const handleResize = debounce(function () {
+        setWindowSize({
+          width: window.innerWidth,
+          height: window.innerHeight,
+        });
+      }, debounceMs);
 
-  useEffect(() => {
-    function handleResize() {
-      setWindowSize({
-        width: window.innerWidth,
-        height: window.innerHeight,
-      });
-    }
+      window.addEventListener("resize", handleResize);
+      // Call handler once initially to ensure correct size
+      handleResize();
 
-    window.addEventListener("resize", handleResize);
-    //
-    // Call handler once initially to ensure correct size
-    handleResize();
+      // Cleanup function
+      return function () {
+        window.removeEventListener("resize", handleResize);
+        handleResize.cancel();
+      };
+    },
+    [debounceMs],
+  );
 
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, [debounceMs]); // Only re-run effect if debounceMs changes
-
-  return {
-    width: debouncedWidth,
-    height: debouncedHeight,
-  };
+  return windowSize;
 }

--- a/src/lib/background-js/background.ts
+++ b/src/lib/background-js/background.ts
@@ -1,0 +1,223 @@
+import debounce from "lodash.debounce";
+
+import {
+  type PartialConfig,
+  svgQuerySchema,
+  toUrlSearchParams,
+} from "@/lib/svg-api/helpers";
+
+/**
+ * Use this script like:
+ *
+ * ```html
+ * <script>
+ *  import { TENPRINT } from "https://10print.xys/static/background.js"
+ *
+ *  TENPRINT({
+ *    gridSize: 10,
+ *    lineThickness: 1,
+ *    firstColour: "#000000",
+ *    secondColour: "#FFFFFF",
+ *  }, document.body)
+ * </script>
+ * ```
+ * and the `document.body` element will have a background image set to a random
+ * 10PRINT image.
+ *
+ * If you don't need to pass custom parameters and want to update the body, use
+ * {@link ./background-body.ts} instead.
+ */
+
+/**
+ * The base URL of the API
+ *
+ * @example https://10print.xyz/svg
+ */
+const API_BASE_URL = (() => {
+  // In dev, the API is served by `wrangler pages dev` which runs on
+  // http://localhost:8788.
+  const ourUrl = import.meta.env.PROD
+    ? import.meta.url
+    : "http://localhost:8788";
+
+  const url = new URL(ourUrl);
+
+  url.pathname = "/svg";
+
+  return url.toString();
+})();
+
+/**
+ * Don't make requests to the SVG API more than this often, in milliseconds.
+ */
+const DEBOUNCE_MS = 100;
+
+/**
+ * Key used in localStorage for the random seed. Saved so that the same image is
+ * shown when the page is reloaded.
+ */
+const LOCAL_STORAGE_KEY = "background-seed";
+
+/**
+ * Saves seed to localStorage
+ */
+export function saveSeed(seed: number): void {
+  localStorage.setItem(LOCAL_STORAGE_KEY, seed.toString());
+}
+
+/**
+ * Fetches and parses a saved seed from localStorage. If the stored seed is
+ * invalid (not a number), it will be removed from localStorage.
+ *
+ * @returns The parsed seed, or null if there is no seed or it's invalid,
+ */
+export function getSavedSeed(): number | undefined {
+  const savedSeed = localStorage.getItem(LOCAL_STORAGE_KEY);
+
+  if (savedSeed === null) {
+    return undefined;
+  }
+
+  const parsedSeed = parseInt(savedSeed, 10);
+
+  if (Number.isNaN(parsedSeed)) {
+    console.warn(`Invalid seed "${savedSeed}" found in localStorage, removing`);
+    localStorage.removeItem(LOCAL_STORAGE_KEY);
+  }
+
+  return parsedSeed;
+}
+
+/**
+ * Builds the image URL with the given parameters
+ *
+ * @param baseUrl The base URL of the API
+ * @param params The parameters to build the URL with
+ *
+ * @returns The constructed image URL to fetch the SVG from.
+ */
+export function buildImageUrl(baseUrl: string, params: PartialConfig): string {
+  const searchParams = toUrlSearchParams(params);
+
+  const url = new URL(baseUrl);
+  url.search = searchParams.toString();
+
+  return url.toString();
+}
+
+/**
+ * Converts SVG text to a data URL.
+ *
+ * @param svgText The SVG text to convert
+ */
+export function svgToDataUrl(svgText: string): string {
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svgText)}`;
+}
+
+/**
+ * Fetches the SVG from the given URL and sets the background image of the
+ * element.
+ *
+ * @param element The element to set the background image on
+ * @param url The URL to fetch the SVG from
+ */
+function setImage(element: HTMLElement, url: string): void {
+  fetch(url)
+    .then((response) => {
+      const contentType = response.headers.get("content-type");
+
+      if (contentType !== "image/svg+xml") {
+        throw new Error(
+          `Expected content type "image/svg+xml", got "${contentType ?? "unknown"}"`,
+        );
+      }
+
+      return response.text();
+    })
+    .then((svgText) => {
+      const dataUrl = svgToDataUrl(svgText);
+      element.style.backgroundImage = `url('${dataUrl}')`;
+    })
+    .catch((error: unknown) => {
+      console.error("Error setting background image", error);
+    });
+}
+
+/**
+ * Options for the TENPRINT function
+ */
+interface TENPRINTOptions {
+  /**
+   * Whether to use a seed stored in localStorage, if available. If `false`,
+   * a new seed will be generated each time the SVG is updated.
+   *
+   * If `true`, the seed will be saved to localStorage when the SVG is updated.
+   *
+   * @default false
+   */
+  saveSeed?: boolean;
+
+  /**
+   * Whether to observe the element's resize and update the background image
+   * when it changes.
+   *
+   * @default false
+   */
+  observeResize?: boolean;
+}
+
+/**
+ * Sets the background image of the element to a random 10PRINT image.
+ *
+ * If `params` doesn't contain values for `width` and `height`, the element's
+ * dimensions will be used.
+ *
+ * @param params The parameters to build the URL with
+ * @param element The element to set the background image on
+ * @param options The options for the TENPRINT function
+ */
+export function TENPRINT(
+  element: HTMLElement,
+  params: PartialConfig = {},
+  { saveSeed = true, observeResize = true }: TENPRINTOptions = {},
+): void {
+  let { width, height, seed } = params;
+
+  if (saveSeed && seed === undefined) {
+    seed = getSavedSeed() ?? undefined;
+  }
+
+  // Use the element's dimensions if not provided
+  if (width === undefined || height === undefined) {
+    const { width: elementWidth, height: elementHeight } =
+      element.getBoundingClientRect();
+
+    width = width ?? elementWidth;
+    height = height ?? elementHeight;
+  }
+
+  const parsedParams = svgQuerySchema.parse({
+    width,
+    height,
+    seed,
+    ...params,
+  });
+
+  element.style.backgroundSize = "cover";
+
+  const url = buildImageUrl(API_BASE_URL, parsedParams);
+
+  function update() {
+    setImage(element, url);
+  }
+
+  update();
+
+  if (!observeResize) {
+    return;
+  }
+
+  const debouncedUpdate = debounce(update, DEBOUNCE_MS);
+  const resizeObserver = new ResizeObserver(debouncedUpdate);
+  resizeObserver.observe(element);
+}

--- a/src/lib/svg-api/helpers.test.ts
+++ b/src/lib/svg-api/helpers.test.ts
@@ -12,7 +12,7 @@ import {
   svgQuerySchema,
 } from "./helpers";
 
-const BASE_URL = "http://localhost/api/svg";
+const BASE_URL = "http://localhost/svg";
 
 describe("SVG API Helpers", () => {
   describe("parseAndValidateQueryParameters", () => {
@@ -22,7 +22,7 @@ describe("SVG API Helpers", () => {
       const url = new URL(
         `${BASE_URL}?width=200&height=100&gridSize=15&firstColour=%23ff0000`,
       );
-      const params = await parseAndValidateQueryParameters(url);
+      const params = await parseAndValidateQueryParameters(url.searchParams);
       expect(params.width).toBe(200);
       expect(params.height).toBe(100);
       expect(params.gridSize).toBe(15);
@@ -32,8 +32,8 @@ describe("SVG API Helpers", () => {
     });
 
     it("should use default values for missing optional parameters", async () => {
-      const url = new URL(`${BASE_URL}?width=50&height=50`);
-      const params = await parseAndValidateQueryParameters(url);
+      const { searchParams } = new URL(`${BASE_URL}?width=50&height=50`);
+      const params = await parseAndValidateQueryParameters(searchParams);
       expect(params.width).toBe(50);
       expect(params.height).toBe(50);
       expect(params.gridSize).toBe(defaults.gridSize);
@@ -63,16 +63,16 @@ describe("SVG API Helpers", () => {
     it.each(invalidParamCases)(
       "should reject request with $name",
       async ({ query }) => {
-        const url = new URL(`${BASE_URL}${query}`);
-        await expect(parseAndValidateQueryParameters(url)).rejects.toThrow(
-          ZodError,
-        );
+        const { searchParams } = new URL(`${BASE_URL}${query}`);
+        await expect(
+          parseAndValidateQueryParameters(searchParams),
+        ).rejects.toThrow(ZodError);
       },
     );
 
     it("should parse parameters provided as strings", async () => {
       const url = new URL(`${BASE_URL}?width=300&height=150&gridSize=25`);
-      const params = await parseAndValidateQueryParameters(url);
+      const params = await parseAndValidateQueryParameters(url.searchParams);
       expect(params.width).toBe(300);
       expect(params.height).toBe(150);
       expect(params.gridSize).toBe(25);

--- a/src/lib/svg-api/index.ts
+++ b/src/lib/svg-api/index.ts
@@ -1,5 +1,7 @@
 export {
   type NormalisedRequest as ProcessedSvgRequest,
-  processSvgRequest,
+  processSvgRequestUrl,
   type SvgQueryParams,
+  svgQuerySchema,
+  widthHeightSchema,
 } from "./helpers";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,11 +6,8 @@
     "checkJs": true,
     "esModuleInterop": true,
     "jsx": "react-jsx",
-    "lib": [
-      "DOM",
-      "DOM.Iterable",
-      "esnext"
-    ],
+    "inlineSources": true,
+    "lib": ["DOM", "DOM.Iterable", "esnext"],
     "module": "esnext",
     "moduleResolution": "bundler",
     "noFallthroughCasesInSwitch": true,
@@ -19,30 +16,17 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     },
     "pretty": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
+    "sourceMap": true,
     "strict": true,
     "strictNullChecks": true,
     "target": "esnext",
-    "types": [
-      "vite/client"
-    ]
+    "types": ["vite/client"]
   },
-  "exclude": [
-    "dist",
-    "node_modules",
-  ],
-  "include": [
-    "eslint.config.mjs",
-    "functions/**/*.ts",
-    "src/**/*.ts",
-    "src/**/*.tsx",
-    "vite.config.ts",
-    "vitest.config.ts"
-  ],
+  "exclude": ["dist", "node_modules"],
+  "include": ["eslint.config.mjs", "**/*.ts", "**/*.tsx"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,4 +13,25 @@ export default defineConfig({
       "@": src,
     },
   },
+  build: {
+    sourcemap: true,
+    rollupOptions: {
+      input: {
+        background: path.resolve(__dirname, "background-element.ts"),
+        backgroundbody: path.resolve(__dirname, "background-body.ts"),
+        demo: path.resolve(__dirname, "demo.html"),
+        main: path.resolve(__dirname, "index.html"),
+      },
+      output: {
+        entryFileNames: function (chunkInfo) {
+          const filenameMap: Record<string, string> = {
+            background: "background.js",
+            backgroundbody: "background-body.js",
+          };
+
+          return filenameMap[chunkInfo.name] ?? "assets/[name]-[hash].js";
+        },
+      },
+    },
+  },
 });


### PR DESCRIPTION
We added this endpoint recently. Here are a couple of JS files served as `/background{,-body}.js` which call the endpoint and sets the SVG as the `<body>` (or an arbitrary) element's background. A debounced event listener is also optionally put in place to resize on window size change, similar to what we have in the React frontend.