### PR TITLE
fix(demo): fix text positioning in Safari by enabling overflow

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -28,7 +28,7 @@
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 100 100"
       preserveAspectRatio="xMidYMid meet"
-      class="aspect-square h-auto w-[90vmin] animate-[spin_10s_linear_infinite] fill-current"
+      class="aspect-square h-auto w-[80vmin] animate-[spin_10s_linear_infinite] fill-current overflow-visible"
     >
       <circle
         id="textCircle"
@@ -65,8 +65,8 @@
       </foreignObject>
 
       <text
+        class="font-mono subpixel-antialiased"
         dominant-baseline="hanging"
-        class="font-mono text-xl"
         fill="url(#textGradient)"
       >
         <textPath
@@ -75,7 +75,6 @@
           startOffset="0%"
           textLength="250%"
           lengthAdjust="spacing"
-          side="right"
         >
           why hello there
         </textPath>


### PR DESCRIPTION
Safari's SVG support doesn't seem to be the best. The dominant baseline isn't working like it is in Chrome, and with `dy` to manually adjust, the text is clipped as if it hadn't been moved. Fix this by allowing clipping (visible), and then setting dy.
