### PR TITLE
fix(renovate): remove `RENOVATE_USERNAME`

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -48,7 +48,7 @@ jobs:
           app-id: ${{ secrets.LANEYBOT_APP_ID }}
           private-key: ${{ secrets.LANEYBOT_PRIVATE_KEY }}
 
-      - name: Self-hosted Renovate
+      - name: Self-hosted Renovate what
         uses: renovatebot/github-action@f5c3383cb7cbf7711d8b66b809375b2d5f4e2d1d # v42.0.2
         with:
           configurationFile: .github/renovate-config.json5
@@ -69,4 +69,3 @@ jobs:
             'full' || null }}
           RENOVATE_PLATFORM: github
           RENOVATE_REPOSITORIES: ${{ github.repository }}
-          RENOVATE_USERNAME: laneybot


### PR DESCRIPTION
This should have been set to `laneybot[bot]` to work properly. But it turns out it's not actually needed at all, since Renovate can find it itself. So it'll be better to just drop it altogether.
