### PR TITLE
chore(renovate): group non-major updates, replace some config with presets

### DIFF
--- a/.github/renovate-config.json5
+++ b/.github/renovate-config.json5
@@ -14,32 +14,24 @@
     },
   ],
   forkProcessing: "enabled",
-  globalExtends: ["config:best-practices"],
-  lockFileMaintenance: {
-    enabled: true,
-    automerge: true,
-  },
+  globalExtends: [
+    "config:best-practices",
+    "group:allNonMajor",
+    ":automergeMinor",
+    ":enableVulnerabilityAlertsWithLabel(automerge-security-update)",
+    ":maintainLockFilesWeekly",
+  ],
   onboarding: false,
   osvVulnerabilityAlerts: true,
+  schedule: ["before 2am on every day"],
   packageRules: [
     {
       labels: ["update-major"],
       matchUpdateTypes: ["major"],
     },
     {
-      labels: ["automerge", "update-minor"],
-      matchUpdateTypes: ["minor"],
-      automerge: true,
-    },
-    {
-      labels: ["automerge", "update-patch"],
-      matchUpdateTypes: ["patch"],
-      automerge: true,
-    },
-    {
       labels: ["update-digest"],
       matchUpdateTypes: ["digest"],
-      automerge: true,
     },
     {
       // Run the custom matcher on early Monday mornings (UTC)
@@ -50,8 +42,4 @@
   platformCommit: "enabled",
   rebaseWhen: "behind-base-branch",
   requireConfig: "optional",
-  vulnerabilityAlerts: {
-    enabled: true,
-    labels: ["automerge-security-update"],
-  },
 }


### PR DESCRIPTION
The current config creates a separate PR for each update. Since we're using npm packages, this is a _lot_. Run Renovate once a day, and configure it to group all non-major updates together, so that we get far fewer.

While we're here, some of the config can be removed and replaced with presets, just to simplify things a bit.
