### PR TITLE
fix: don’t convert string to string

### DIFF
--- a/src/lib/background-js/background.ts
+++ b/src/lib/background-js/background.ts
@@ -75,7 +75,7 @@ export function saveSeed(
     return undefined;
   }
 
-  localStorage.setItem(key, seed.toString());
+  localStorage.setItem(key, seed);
 
   return parsedSeed;
 }


### PR DESCRIPTION
We’re calling `toString()` on something which is already a string. That’s now creating a lint warning.