### PR TITLE
feat: use catppuccin themes

### DIFF
--- a/app.css
+++ b/app.css
@@ -4,6 +4,66 @@
 
 @custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
 
+/* Catppuccin Latte (Light) */
+@theme {
+  --color-ctp-rosewater: #dc8a78;
+  --color-ctp-flamingo: #dd7878;
+  --color-ctp-pink: #ea76cb;
+  --color-ctp-mauve: #8839ef;
+  --color-ctp-red: #d20f39;
+  --color-ctp-maroon: #e64553;
+  --color-ctp-peach: #fe640b;
+  --color-ctp-yellow: #df8e1d;
+  --color-ctp-green: #40a02b;
+  --color-ctp-teal: #179299;
+  --color-ctp-sky: #04a5e5;
+  --color-ctp-sapphire: #209fb5;
+  --color-ctp-blue: #1e66f5;
+  --color-ctp-lavender: #7287fd;
+  --color-ctp-text: #4c4f69;
+  --color-ctp-subtext1: #5c5f77;
+  --color-ctp-subtext0: #6c6f85;
+  --color-ctp-overlay2: #7c7f93;
+  --color-ctp-overlay1: #8c8fa1;
+  --color-ctp-overlay0: #9ca0b0;
+  --color-ctp-surface2: #acb0be;
+  --color-ctp-surface1: #bcc0cc;
+  --color-ctp-surface0: #ccd0da;
+  --color-ctp-base: #eff1f5;
+  --color-ctp-mantle: #e6e9ef;
+  --color-ctp-crust: #dce0e8;
+}
+
+/* Catppuccin Frappé */
+[data-theme="dark"] {
+  --color-ctp-rosewater: #f2d5cf;
+  --color-ctp-flamingo: #eebebe;
+  --color-ctp-pink: #f4b8e4;
+  --color-ctp-mauve: #ca9ee6;
+  --color-ctp-red: #e78284;
+  --color-ctp-maroon: #ea999c;
+  --color-ctp-peach: #ef9f76;
+  --color-ctp-yellow: #e5c890;
+  --color-ctp-green: #a6d189;
+  --color-ctp-teal: #81c8be;
+  --color-ctp-sky: #99d1db;
+  --color-ctp-sapphire: #85c1dc;
+  --color-ctp-blue: #8caaee;
+  --color-ctp-lavender: #babbf1;
+  --color-ctp-text: #c6d0f5;
+  --color-ctp-subtext1: #b5bfe2;
+  --color-ctp-subtext0: #a5adce;
+  --color-ctp-overlay2: #949cbb;
+  --color-ctp-overlay1: #838ba7;
+  --color-ctp-overlay0: #737994;
+  --color-ctp-surface2: #626880;
+  --color-ctp-surface1: #51576d;
+  --color-ctp-surface0: #414559;
+  --color-ctp-base: #303446;
+  --color-ctp-mantle: #292c3c;
+  --color-ctp-crust: #232634;
+}
+
 select.dark {
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%23d1d5db' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
 }
@@ -17,111 +77,101 @@ select {
   padding-right: 2.5rem;
 }
 
-:root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
-}
+@theme {
+  /* Background and text */
+  --background: var(--color-ctp-base);
+  --foreground: var(--color-ctp-text);
 
-[data-theme="dark"] {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  /* Cards and popovers */
+  --card: var(--color-ctp-base);
+  --card-foreground: var(--color-ctp-text);
+  --popover: var(--color-ctp-base);
+  --popover-foreground: var(--color-ctp-text);
+
+  /* Primary colours */
+  --primary: var(--color-ctp-lavender);
+  --primary-foreground: var(--color-ctp-base);
+
+  /* Secondary colours */
+  --secondary: var(--color-ctp-mantle);
+  --secondary-foreground: var(--color-ctp-text);
+
+  /* Muted colours */
+  --muted: var(--color-ctp-surface0);
+  --muted-foreground: var(--color-ctp-subtext0);
+
+  /* Accent colours */
+  --accent: var(--color-ctp-surface0);
+  --accent-foreground: var(--color-ctp-text);
+
+  /* Destructive colours */
+  --destructive: var(--color-ctp-red);
+  --destructive-foreground: var(--color-ctp-mantle);
+
+  /* Borders and inputs */
+  --border: var(--color-ctp-surface1);
+  --input: var(--color-ctp-surface1);
+  --ring: var(--color-ctp-blue);
+
+  /* Chart colours */
+  --chart-1: var(--color-ctp-red);
+  --chart-2: var(--color-ctp-teal);
+  --chart-3: var(--color-ctp-blue);
+  --chart-4: var(--color-ctp-yellow);
+  --chart-5: var(--color-ctp-green);
+
+  /* Sidebar colours */
+  --sidebar: var(--color-ctp-mantle);
+  --sidebar-foreground: var(--color-ctp-text);
+  --sidebar-primary: var(--color-ctp-blue);
+  --sidebar-primary-foreground: var(--color-ctp-base);
+  --sidebar-accent: var(--color-ctp-surface0);
+  --sidebar-accent-foreground: var(--color-ctp-text);
+  --sidebar-border: var(--color-ctp-surface1);
+  --sidebar-ring: var(--color-ctp-blue);
 }
 
 @theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-sidebar-ring: var(--sidebar-ring);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar: var(--sidebar);
+  --color-chart-5: var(--chart-5);
+  --color-chart-4: var(--chart-4);
+  --color-chart-3: var(--chart-3);
+  --color-chart-2: var(--chart-2);
+  --color-chart-1: var(--chart-1);
+  --color-ring: var(--ring);
+  --color-input: var(--input);
+  --color-border: var(--border);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-accent: var(--accent);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-muted: var(--muted);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-secondary: var(--secondary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-primary: var(--primary);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-popover: var(--popover);
+  --color-card-foreground: var(--card-foreground);
+  --color-card: var(--card);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --color-card: var(--card);
-  --color-card-foreground: var(--card-foreground);
-  --color-popover: var(--popover);
-  --color-popover-foreground: var(--popover-foreground);
-  --color-primary: var(--primary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-secondary: var(--secondary);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-muted: var(--muted);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-accent: var(--accent);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-destructive: var(--destructive);
-  --color-border: var(--border);
-  --color-input: var(--input);
-  --color-ring: var(--ring);
-  --color-chart-1: var(--chart-1);
-  --color-chart-2: var(--chart-2);
-  --color-chart-3: var(--chart-3);
-  --color-chart-4: var(--chart-4);
-  --color-chart-5: var(--chart-5);
-  --color-sidebar: var(--sidebar);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-ring: var(--sidebar-ring);
+}
+
+:root {
+  --radius: 0.625rem;
 }
 
 @layer base {

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -51,8 +51,8 @@ function Section({
       aria-labelledby={titleId}
       className={cn("min-w-0 space-y-4", className)}
     >
-      <div className="flex items-center justify-between border-b border-neutral-200 pb-2 dark:border-neutral-800">
-        <h3 id={titleId} className="font-medium">
+      <div className="border-border flex items-center justify-between border-b">
+        <h3 id={titleId} className="mb-1 font-medium">
           {title}
         </h3>
         {action}


### PR DESCRIPTION
The best. Latte for light, frappe for dark. This showed up that we were using the wrong border colour for section dividers. Fix to use `border-border`.
