### PR TITLE
chore(deps): pin @vitest/browser-playwright to match vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/seedrandom": "3.0.8",
     "@typescript-eslint/utils": "8.56.1",
     "@vitejs/plugin-react": "5.1.4",
-    "@vitest/browser-playwright": "^4.0.18",
+    "@vitest/browser-playwright": "4.0.18",
     "@vitest/coverage-v8": "4.0.18",
     "eslint": "10.0.2",
     "eslint-config-prettier": "10.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,7 +143,7 @@ importers:
         specifier: 5.1.4
         version: 5.1.4(vite@7.3.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1))
       '@vitest/browser-playwright':
-        specifier: ^4.0.18
+        specifier: 4.0.18
         version: 4.0.18(playwright@1.58.2)(vite@7.3.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1))(vitest@4.0.18)
       '@vitest/coverage-v8':
         specifier: 4.0.18


### PR DESCRIPTION
## Summary

The lock-file-maintenance PR (#653) was hanging `build-test-lint` until the 6h job timeout, blocking it from merging.

**Root cause:** `@vitest/browser-playwright` was the only `@vitest/*` package with a caret specifier (`^4.0.18`); `vitest`, `@vitest/coverage-v8` are pinned exactly to `4.0.18`. Renovate's weekly `lockFileMaintenance` refreshed `@vitest/browser-playwright` to `4.1.5`, which pulled in `@vitest/browser@4.1.5` as a peer. With `vitest` still at `4.0.18`, vitest reported `Running mixed versions is not supported` and the browser test hung indefinitely.

Reproduced locally by checking out the renovate branch's `pnpm-lock.yaml`: the unit tests all pass, then the `browser (chromium)` test hangs forever. Restoring the lockfile makes it pass in ~5s.

**Fix:** Pin `@vitest/browser-playwright` to `4.0.18` (no caret), matching the other `@vitest/*` pins, so future lockfile refreshes can't drift it past `vitest`. The lockfile diff is just the specifier change — same resolved version.

Once this lands, rebasing #653 will produce a consistent set and unblock it.

## Test plan

- [x] `pnpm install --frozen-lockfile` (clean)
- [x] `pnpm wrangler types worker-configuration.d.ts --check`
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] `pnpm run test` (all 80 tests pass, including the `browser (chromium)` BottomSheet test)
- [ ] Verify #653 unblocks once rebased on top of this fix


---
_Generated by [Claude Code](https://claude.ai/code/session_01UkjKmtMf3weiPnJHpe6uqd)_