### PR TITLE
chore(renovate): pull pin updates out of group:monorepos

### DIFF
--- a/.github/renovate-config.json5
+++ b/.github/renovate-config.json5
@@ -37,6 +37,15 @@
       matchUpdateTypes: ["digest"],
     },
     {
+      // Don't fold pin updates into the monorepo/non-major groups - those
+      // groups can be empty (when the other monorepo siblings are already
+      // pinned) and the pin update silently disappears with them. Forcing a
+      // null groupName makes Renovate raise pin updates as standalone PRs.
+      matchUpdateTypes: ["pin"],
+      groupName: null,
+      groupSlug: null,
+    },
+    {
       // Run the custom matcher on early Monday mornings (UTC)
       schedule: "* 0-4 * * 1",
       matchPackageNames: ["ghcr.io/renovatebot/renovate"],


### PR DESCRIPTION
## Summary

`config:best-practices` already extends `:pinDevDependencies` (sets `rangeStrategy: "pin"` on devDependencies), and Renovate has been auto-pinning most devDeps as they were added — there are 7+ historical "pin dependencies" PRs.

But `@vitest/browser-playwright`, added 2 months ago in `feat: replace the old controls with a native-feeling bottom sheet` (fcdd729), kept its `^4.0.18` caret indefinitely — Renovate never opened a pin PR for it. Weekly `lockFileMaintenance` then drifted it to `4.1.5` (pulling in `@vitest/browser@4.1.5`), while `vitest` stayed at `4.0.18` exact, and browser tests hung in CI for 6 hours, blocking #653. The point fix for the version mismatch is #661.

The likely root cause: `group:monorepos` is folding the pin update into the vitest monorepo group, but the other vitest packages (`vitest`, `@vitest/coverage-v8`) are already pinned. The resulting group is empty, and Renovate drops the PR.

This packageRule forces pin updates to raise as their own standalone PRs by clearing `groupName`/`groupSlug` for `matchUpdateTypes: ["pin"]`.

## Plan

Land this; on the next Renovate run (scheduled `before 2am UTC`), it should produce a `chore(deps): pin dependency @vitest/browser-playwright to 4.0.18` PR. If it does, #661 can be closed in favour of the auto-generated one. If it doesn't shake out, #661 is still ready to merge as the manual fix.

## Test plan

- [ ] Land this PR
- [ ] Wait for the next Renovate cycle
- [ ] Confirm an auto-pin PR appears for `@vitest/browser-playwright` (and any other unpinned devDeps that have been similarly stuck)
- [ ] Close #661 if the auto-pin lands cleanly; otherwise merge #661


---
_Generated by [Claude Code](https://claude.ai/code/session_01UkjKmtMf3weiPnJHpe6uqd)_